### PR TITLE
collection-name-indexing: modifications to RELS-EXT_to_solr.xslt to add collection name solr indexing

### DIFF
--- a/RELS-EXT_to_solr.xslt
+++ b/RELS-EXT_to_solr.xslt
@@ -117,5 +117,44 @@
           </field>
         </xsl:otherwise>
       </xsl:choose>
+
+        <!--
+        Added 12/16/2016 by Pat Dunlavey, to add collection name to the indexed values
+        see https://ficial.wordpress.com/2014/04/14/islandora-7-solr-faceting-by-collection-name-or-label/
+        -->
+        <xsl:for-each select="$content//rdf:Description/*[@rdf:resource]">
+
+            <xsl:if test="local-name()='isMemberOfCollection'">
+                <xsl:variable name="collectionPID"
+                              select="substring-after(@rdf:resource,'info:fedora/')"/>
+                <xsl:variable name="collectionContent"
+                              select="document(concat($PROT, '://', $FEDORAUSERNAME, ':', $FEDORAPASSWORD, '@', $HOST, ':', $PORT,'/fedora/objects/', $collectionPID, '/datastreams/', 'DC', '/content'))"/>
+
+                <field name="collection_membership.pid_ms">
+                    <xsl:value-of select="$collectionPID"/>
+                </field>
+
+                <xsl:for-each select="$collectionContent//dc:title">
+                    <xsl:if test="local-name()='title'">
+                        <field name="collection_membership.title_ms">
+                            <xsl:value-of select="text()"/>
+                        </field>
+                        <field name="collection_membership.title_mt">
+                            <xsl:value-of select="text()"/>
+                        </field>
+                    </xsl:if>
+                </xsl:for-each>
+
+            </xsl:if>
+            <!--
+                <xsl:if test="local-name()='hasModel'">
+                <xsl:variable name="modelPID" select="substring-after(@rdf:resource,'info:fedora/')"/>
+                <field name="CSW_test_if_model">
+                  <xsl:value-of select="$modelPID"/>
+                </field>
+                </xsl:if>
+            -->
+        </xsl:for-each>
+
     </xsl:template>
 </xsl:stylesheet>

--- a/RELS-EXT_to_solr.xslt
+++ b/RELS-EXT_to_solr.xslt
@@ -1,160 +1,173 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- RELS-EXT -->
+<!-- Added encoder and dc namespaces for collection name indexing -->
 <xsl:stylesheet version="1.0"
-    xmlns:java="http://xml.apache.org/xalan/java"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:foxml="info:fedora/fedora-system:def/foxml#"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" exclude-result-prefixes="rdf java">
+                xmlns:java="http://xml.apache.org/xalan/java"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+                xmlns:encoder="xalan://java.net.URLEncoder"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                exclude-result-prefixes="rdf java">
 
-    <xsl:variable name="single_valued_hashset_for_rels_ext" select="java:java.util.HashSet.new()"/>
+    <xsl:variable name="single_valued_hashset_for_rels_ext"
+                  select="java:java.util.HashSet.new()"/>
 
-    <xsl:template match="foxml:datastream[@ID='RELS-EXT']/foxml:datastreamVersion[last()]"
+    <xsl:template
+        match="foxml:datastream[@ID='RELS-EXT']/foxml:datastreamVersion[last()]"
         name="index_RELS-EXT">
         <xsl:param name="content"/>
         <xsl:param name="prefix">RELS_EXT_</xsl:param>
         <xsl:param name="suffix">_ms</xsl:param>
 
         <!-- Clearing hash in case the template is ran more than once. -->
-        <xsl:variable name="return_from_clear" select="java:clear($single_valued_hashset_for_rels_ext)"/>
+        <xsl:variable name="return_from_clear"
+                      select="java:clear($single_valued_hashset_for_rels_ext)"/>
 
-        <xsl:apply-templates select="$content//rdf:Description/* | $content//rdf:description/*" mode="rels_ext_element">
-          <xsl:with-param name="prefix" select="$prefix"/>
-          <xsl:with-param name="suffix" select="$suffix"/>
+        <xsl:apply-templates
+            select="$content//rdf:Description/* | $content//rdf:description/*"
+            mode="rels_ext_element">
+            <xsl:with-param name="prefix" select="$prefix"/>
+            <xsl:with-param name="suffix" select="$suffix"/>
         </xsl:apply-templates>
-    </xsl:template>
-
-    <!-- Match elements, call underlying template. -->
-    <xsl:template match="*[@rdf:resource]" mode="rels_ext_element">
-      <xsl:param name="prefix"/>
-      <xsl:param name="suffix"/>
-
-      <xsl:call-template name="rels_ext_fields">
-        <xsl:with-param name="prefix" select="$prefix"/>
-        <xsl:with-param name="suffix" select="$suffix"/>
-        <xsl:with-param name="type">uri</xsl:with-param>
-        <xsl:with-param name="value" select="@rdf:resource"/>
-      </xsl:call-template>
-    </xsl:template>
-    <xsl:template match="*[normalize-space(.)]" mode="rels_ext_element">
-      <xsl:param name="prefix"/>
-      <xsl:param name="suffix"/>
-
-      <xsl:call-template name="rels_ext_fields">
-        <xsl:with-param name="prefix" select="$prefix"/>
-        <xsl:with-param name="suffix" select="$suffix"/>
-        <xsl:with-param name="type">literal</xsl:with-param>
-        <xsl:with-param name="value" select="text()"/>
-      </xsl:call-template>
-    </xsl:template>
-
-    <!-- Fork between fields without and with the namespace URI in the field
-      name. -->
-    <xsl:template name="rels_ext_fields">
-      <xsl:param name="prefix"/>
-      <xsl:param name="suffix"/>
-      <xsl:param name="type"/>
-      <xsl:param name="value"/>
-
-      <xsl:call-template name="rels_ext_field">
-        <xsl:with-param name="prefix" select="$prefix"/>
-        <xsl:with-param name="suffix" select="$suffix"/>
-        <xsl:with-param name="type" select="$type"/>
-        <xsl:with-param name="value" select="$value"/>
-      </xsl:call-template>
-      <xsl:call-template name="rels_ext_field">
-        <xsl:with-param name="prefix" select="concat($prefix, namespace-uri())"/>
-        <xsl:with-param name="suffix" select="$suffix"/>
-        <xsl:with-param name="type" select="$type"/>
-        <xsl:with-param name="value" select="$value"/>
-      </xsl:call-template>
-    </xsl:template>
-
-    <!-- Actually create a field. -->
-    <xsl:template name="rels_ext_field">
-      <xsl:param name="prefix"/>
-      <xsl:param name="suffix"/>
-      <xsl:param name="type"/>
-      <xsl:param name="value"/>
-
-      <!-- Prevent multiple generating multiple instances of single-valued fields
-      by tracking things in a HashSet -->
-      <!-- The method java.util.HashSet.add will return false when the value is
-      already in the set. -->
-      <xsl:choose>
-        <xsl:when
-          test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_', $type, '_s'))">
-          <field>
-            <xsl:attribute name="name">
-              <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_s')"/>
-            </xsl:attribute>
-            <xsl:value-of select="$value"/>
-          </field>
-          <xsl:choose>
-            <xsl:when test="@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#int'">
-              <field>
-                <xsl:attribute name="name">
-                  <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_l')"/>
-                </xsl:attribute>
-                <xsl:value-of select="$value"/>
-              </field>
-            </xsl:when>
-            <xsl:when test="floor($value) = $value">
-              <field>
-                <xsl:attribute name="name">
-                  <xsl:value-of select="concat($prefix, local-name(), '_', $type, '_intDerivedFromString_l')"/>
-                </xsl:attribute>
-                <xsl:value-of select="$value"/>
-              </field>
-            </xsl:when>
-          </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-          <field>
-            <xsl:attribute name="name">
-              <xsl:value-of select="concat($prefix, local-name(), '_', $type, $suffix)"/>
-            </xsl:attribute>
-            <xsl:value-of select="$value"/>
-          </field>
-        </xsl:otherwise>
-      </xsl:choose>
 
         <!--
-        Added 12/16/2016 by Pat Dunlavey, to add collection name to the indexed values
-        see https://ficial.wordpress.com/2014/04/14/islandora-7-solr-faceting-by-collection-name-or-label/
+        Add collection name to the indexed fields
+        based on https://ficial.wordpress.com/2014/04/14/islandora-7-solr-faceting-by-collection-name-or-label/
         -->
         <xsl:for-each select="$content//rdf:Description/*[@rdf:resource]">
-
+            
             <xsl:if test="local-name()='isMemberOfCollection'">
                 <xsl:variable name="collectionPID"
                               select="substring-after(@rdf:resource,'info:fedora/')"/>
                 <xsl:variable name="collectionContent"
-                              select="document(concat($PROT, '://', $FEDORAUSERNAME, ':', $FEDORAPASSWORD, '@', $HOST, ':', $PORT,'/fedora/objects/', $collectionPID, '/datastreams/', 'DC', '/content'))"/>
-
+                              select="document(concat($PROT, '://', encoder:encode($FEDORAUSER), ':', encoder:encode($FEDORAPASS), '@', $HOST, ':', $PORT, '/fedora/objects/', $collectionPID, '/datastreams/', 'DC', '/content'))"/>
                 <field name="collection_membership.pid_ms">
                     <xsl:value-of select="$collectionPID"/>
                 </field>
-
                 <xsl:for-each select="$collectionContent//dc:title">
                     <xsl:if test="local-name()='title'">
                         <field name="collection_membership.title_ms">
                             <xsl:value-of select="text()"/>
                         </field>
-                        <field name="collection_membership.title_mt">
+                    </xsl:if>
+                </xsl:for-each>
+            </xsl:if>
+            <xsl:if test="local-name()='hasModel'">
+                <xsl:variable name="cmodelPID"
+                              select="substring-after(@rdf:resource,'info:fedora/')"/>
+                <xsl:variable name="cmodelDC"
+                              select="document(concat($PROT, '://', encoder:encode($FEDORAUSER), ':', encoder:encode($FEDORAPASS), '@', $HOST, ':', $PORT, '/fedora/objects/', $cmodelPID, '/datastreams/', 'DC', '/content'))"/>
+                <xsl:for-each select="$cmodelDC//dc:title">
+                    <xsl:if test="local-name()='title'">
+                        <field name="content_model.title_ms">
                             <xsl:value-of select="text()"/>
                         </field>
                     </xsl:if>
                 </xsl:for-each>
-
             </xsl:if>
-            <!--
-                <xsl:if test="local-name()='hasModel'">
-                <xsl:variable name="modelPID" select="substring-after(@rdf:resource,'info:fedora/')"/>
-                <field name="CSW_test_if_model">
-                  <xsl:value-of select="$modelPID"/>
-                </field>
-                </xsl:if>
-            -->
         </xsl:for-each>
+    </xsl:template>
 
+    <!-- Match elements, call underlying template. -->
+    <xsl:template match="*[@rdf:resource]" mode="rels_ext_element">
+        <xsl:param name="prefix"/>
+        <xsl:param name="suffix"/>
+
+        <xsl:call-template name="rels_ext_fields">
+            <xsl:with-param name="prefix" select="$prefix"/>
+            <xsl:with-param name="suffix" select="$suffix"/>
+            <xsl:with-param name="type">uri</xsl:with-param>
+            <xsl:with-param name="value" select="@rdf:resource"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template match="*[normalize-space(.)]" mode="rels_ext_element">
+        <xsl:param name="prefix"/>
+        <xsl:param name="suffix"/>
+
+        <xsl:call-template name="rels_ext_fields">
+            <xsl:with-param name="prefix" select="$prefix"/>
+            <xsl:with-param name="suffix" select="$suffix"/>
+            <xsl:with-param name="type">literal</xsl:with-param>
+            <xsl:with-param name="value" select="text()"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Fork between fields without and with the namespace URI in the field
+      name. -->
+    <xsl:template name="rels_ext_fields">
+        <xsl:param name="prefix"/>
+        <xsl:param name="suffix"/>
+        <xsl:param name="type"/>
+        <xsl:param name="value"/>
+
+        <xsl:call-template name="rels_ext_field">
+            <xsl:with-param name="prefix" select="$prefix"/>
+            <xsl:with-param name="suffix" select="$suffix"/>
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:with-param name="value" select="$value"/>
+        </xsl:call-template>
+        <xsl:call-template name="rels_ext_field">
+            <xsl:with-param name="prefix"
+                            select="concat($prefix, namespace-uri())"/>
+            <xsl:with-param name="suffix" select="$suffix"/>
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:with-param name="value" select="$value"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Actually create a field. -->
+    <xsl:template name="rels_ext_field">
+        <xsl:param name="prefix"/>
+        <xsl:param name="suffix"/>
+        <xsl:param name="type"/>
+        <xsl:param name="value"/>
+
+        <!-- Prevent multiple generating multiple instances of single-valued fields
+        by tracking things in a HashSet -->
+        <!-- The method java.util.HashSet.add will return false when the value is
+        already in the set. -->
+        <xsl:choose>
+            <xsl:when
+                test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_', $type, '_s'))">
+                <field>
+                    <xsl:attribute name="name">
+                        <xsl:value-of
+                            select="concat($prefix, local-name(), '_', $type, '_s')"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="$value"/>
+                </field>
+                <xsl:choose>
+                    <xsl:when
+                        test="@rdf:datatype = 'http://www.w3.org/2001/XMLSchema#int'">
+                        <field>
+                            <xsl:attribute name="name">
+                                <xsl:value-of
+                                    select="concat($prefix, local-name(), '_', $type, '_l')"/>
+                            </xsl:attribute>
+                            <xsl:value-of select="$value"/>
+                        </field>
+                    </xsl:when>
+                    <xsl:when test="floor($value) = $value">
+                        <field>
+                            <xsl:attribute name="name">
+                                <xsl:value-of
+                                    select="concat($prefix, local-name(), '_', $type, '_intDerivedFromString_l')"/>
+                            </xsl:attribute>
+                            <xsl:value-of select="$value"/>
+                        </field>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <field>
+                    <xsl:attribute name="name">
+                        <xsl:value-of
+                            select="concat($prefix, local-name(), '_', $type, $suffix)"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="$value"/>
+                </field>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
**Work in progress - do not merge yet. Testing needed!**

# What does this Pull Request do?

The discovery garden RES-EXT_to_solr.xslt indexes the collection PID, but not the collection name. This change adds islandora collection name to object's solr index values. 

# What's new?

A block of code to the RELS-EXT_to_solr.xslt that looks for 'isMemberOfCollection' PIDs. For each found, it loads the DC record for that PID and then extracts the title. Finally, it adds two fields to the index: `collection_membership.title_ms` and `collection_membership.title_mt`.

# How should this be tested?

* Corresponding additions for these two fields should be made to schema.xml and solrconfig.xml. [See here](https://ficial.wordpress.com/2014/04/14/islandora-7-solr-faceting-by-collection-name-or-label):

1. See if running /usr/bin/ant -f $CATALINA_BASE/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml generates new schema.xml and/or solrconfig.xml. If so, great. Then I think you just need to move these files and give the correct ownership and permissions.
2. Otherwise the schema.xml and solrconfig.xml files will need to be manually edited per [Chris's blog post](https://ficial.wordpress.com/2014/04/14/islandora-7-solr-faceting-by-collection-name-or-label).

* If successful, solr reindexing of an object should add `collection_membership.title_ms` and `collection_membership_mt` to all objects with the name of the parent collection(s) (except islandora:root, I think)

**Interested parties**

Tag @g7morris 